### PR TITLE
Mac/no-CUDA support

### DIFF
--- a/amp_gen_no_cuda.yml
+++ b/amp_gen_no_cuda.yml
@@ -1,0 +1,24 @@
+name: amp21_no_cuda
+channels:
+  - anaconda
+  - pytorch
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - pytorch=1.7.1
+  - torchvision
+  - torchaudio
+  - pip>=21.0
+  - pandas
+  - faiss
+  - h5py
+  - matplotlib
+  - seaborn
+  - scikit-learn
+  - biopython
+  - pip:
+      - PyHamcrest
+      - Automat==0.3.0
+      - torchtext==0.3.1
+      - tensorboard_logger
+      - modlamp==4.2.3

--- a/models/model.py
+++ b/models/model.py
@@ -38,7 +38,7 @@ class RNN_VAE(nn.Module):
         self.n_vocab = n_vocab
         self.z_dim = z_dim
         self.c_dim = c_dim
-        self.device = torch.device('cuda')
+        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
         """
         Word embeddings layer

--- a/run_mac.sh
+++ b/run_mac.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# TO DEFAULT OUTPUT DIRS, TINY (DEBUG) RUN
+hypers="--tiny 1 --resume_result_json 0"
+override_runname="" # runname: default  -> tb/default and output/default
+
+git log --graph --full-history --all --oneline | head -n 15
+git status
+
+loadpath="" # empty to resume from local phase 1 VAE pretrain; set to resume another phase1.
+/usr/bin/time python main.py $override_runname $loadpath $hypers --phase 1
+/usr/bin/time python static_eval.py $override_runname $hypers --phase 1 $static_eval_long


### PR DESCRIPTION
Supports running on non-CUDA systems such as Macs. Also explictely provides a Mac run script because the Mac time command doesn't support verbose.

To build on Mac:
```
conda-env create -f amp_gen_no_cuda.yml
```

To run on Mac:
```
./run_mac.sh
```